### PR TITLE
Overriding the required validator to provide paths.

### DIFF
--- a/spectastic/operation.py
+++ b/spectastic/operation.py
@@ -294,15 +294,13 @@ class Operation(object):
                 return
 
             for error in self.validator.iter_errors(request_body, body_schema):
-                if error.validator == 'required':
-                    path = deepcopy(error.path)
-                    path.append(*error.validator_value)
-                else:
-                    path = error.path
-
+                # Relies on our overriden 'required' validator to provide
+                # an error path.
+                path = error.path
                 yield FieldError(error.message, 'body', '.'.join(map(
                     str, path
                 )))
+
 
     def iter_request_path_errors(self, request_path):
         """

--- a/spectastic/validators.py
+++ b/spectastic/validators.py
@@ -50,15 +50,27 @@ def validate_discriminator(validator, discriminator, instance, schema):
             if error.validator == 'required':
                 yield jsonschema.ValidationError(
                     error.message,
-                    path=error.validator_value
+                    path=error.path,
                 )
             else:
                 yield error
+
+
+def validator_required(validator, required, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+    for property in required:
+        if property not in instance:
+            yield jsonschema.ValidationError(
+                "%r is a required property" % property,
+                path=[property],
+            )
 
 #: Extends the Draft4Validator with support for discriminators
 SwaggerValidator = jsonschema.validators.extend(
     jsonschema.Draft4Validator,
     validators={
-        "discriminator": validate_discriminator
+        "discriminator": validate_discriminator,
+        "required": validator_required,
     },
 )


### PR DESCRIPTION
jsonschema's underlying error.validator_value does not refer to the field path. Override the built in required validator with a slightly customized one that tracks the property name.
