### PR TITLE
Add special case handling for empty json bodies.

### DIFF
--- a/spectastic/request.py
+++ b/spectastic/request.py
@@ -30,7 +30,9 @@ class BasicRequest(object):
         if 'content-type' in headers:
             value = headers['content-type']
             if value == 'application/json':
-                if isinstance(body, basestring):
+                if isinstance(body, basestring) and body == '':
+                    body = None
+                elif isinstance(body, basestring):
                     try:
                         body = json.loads(body)
                     except:

--- a/tests/test_spectastic.py
+++ b/tests/test_spectastic.py
@@ -151,6 +151,14 @@ class TestBasicRequest(unittest.TestCase):
             request.body,
         )
 
+    def test_request_body_empty(self):
+        request = BasicRequest(
+            '', {'content-type': 'application/json'}, '', '')
+        self.assertEqual(
+            None,
+            request.body,
+        )
+
     def test_request_body_raw(self):
         request = BasicRequest(
             'hello', {}, '', '')


### PR DESCRIPTION
Oversight - an empty string raises a ValueError when calling json.loads(), assumption was that this was `None`. The primary issue with this is it causes GET requests with Content-Type headers to fail. A GET request generally shouldn't have a body, but it shouldn't raise exceptions either.
